### PR TITLE
docs(): mime 新版本的方法名称改变了

### DIFF
--- a/lesson4/README.md
+++ b/lesson4/README.md
@@ -370,7 +370,7 @@ else{
       return false
     }
     res.writeHead(200, { 
-      'Content-Type': `${mime.lookup(pathname)};charset:UTF-8`
+      'Content-Type': `${mime.getType(pathname)};charset:UTF-8`
     })
     res.write(data, 'binary')
     res.end()


### PR DESCRIPTION
Version 2 is a breaking change from 1.x as the semver implies. Specifically: lookup() renamed to
getType() extension() renamed to getExtension() charset() and load() methods have been removed